### PR TITLE
remove JID.toJSON

### DIFF
--- a/lib/JID.js
+++ b/lib/JID.js
@@ -50,14 +50,6 @@ JID.prototype.toString = function (unescape) {
   return s
 }
 
-JID.prototype.toJSON = function (unescape) {
-  return {
-    local: this.getLocal(unescape),
-    domain: this.getDomain(),
-    resource: this.getResource()
-  }
-}
-
 /**
  * Convenience method to distinguish users
  **/

--- a/test/JID.js
+++ b/test/JID.js
@@ -122,24 +122,6 @@ describe('JID', function () {
     })
   })
 
-  describe('toJSON', function () {
-    it('returns an object with local, domain, resource properties', function () {
-      var jid = new JID('foo@bar/baz')
-      assert.deepEqual(jid.toJSON(), {local: 'foo', domain: 'bar', resource: 'baz'})
-    })
-
-    it('does not unescape local if a falsy argument is passed', function () {
-      var jid = new JID('foo@lol', 'bar', 'baz')
-      assert.strictEqual(jid.toJSON().local, 'foo\\40lol')
-      assert.strictEqual(jid.toJSON(false).local, 'foo\\40lol')
-    })
-
-    it('unescapes local if true is passed', function () {
-      var jid = new JID('foo@lol', 'bar', 'baz')
-      assert.strictEqual(jid.toJSON(true).local, 'foo@lol')
-    })
-  })
-
   describe('equality', function () {
     it('should parsed JIDs should be equal', function () {
       var j1 = new JID('foo@bar/baz')


### PR DESCRIPTION
removes JID.toJSON method

Same logic than ltx, correct behavior is to let JSON.stringify serialize as string